### PR TITLE
Fix displaying of ignored tests with long names

### DIFF
--- a/.github/workflows/mgba-rom-test.yml
+++ b/.github/workflows/mgba-rom-test.yml
@@ -71,6 +71,26 @@ jobs:
         rom-path: ignore_with_message.gba
         success-code: 0  # Pass
 
+  multiple_ignore:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rust-src
+    - run: sudo apt-get install binutils-arm-none-eabi
+    - run: cd tests/multiple_ignore && cargo test --no-run --message-format=json | tee results.json
+    - run: echo "ROM_PATH=$(cd tests/parse_executable && cargo run ../multiple_ignore/results.json)" >> $GITHUB_ENV
+    - run: arm-none-eabi-objcopy -O binary ${{ env.ROM_PATH }} multiple_ignore.gba
+    - run: cargo install gbafix
+    - run: gbafix multiple_ignore.gba
+    - uses: felixjones/github-mgba-rom-test@v1
+      with:
+        swi-call: 0x27
+        read-register: 'r0'
+        rom-path: multiple_ignore.gba
+        success-code: 0  # Pass
+
   fail:
     runs-on: ubuntu-latest
     steps:

--- a/gba_test/CHANGELOG.md
+++ b/gba_test/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Panic displaying now properly clears all previous text before displaying the panic info.
 - User interface no longer panics when attempting to scroll down an empty list.
 - Panics are now properly reported to `mgba-rom-test` using the same bios call as pass/fail reports.
+- Ignored tests with long names no longer cause misaligned display of tests in user interface.
 
 ## 0.1.2 - 2024-06-06
 ### Fixed

--- a/gba_test/src/ui/cursor.rs
+++ b/gba_test/src/ui/cursor.rs
@@ -25,13 +25,13 @@ impl Write for Cursor {
                 self.cursor = (((self.cursor as usize / 0x40) + 1) * 0x40) as *mut u16;
             } else if ascii < 128 {
                 unsafe {
-                    self.cursor
-                        .write_volatile((ascii | ((self.palette as u32) << 12)) as u16);
-                    self.cursor = self.cursor.add(1);
                     // Don't write past the view of the screen.
                     if (self.cursor as usize) % 0x40 > 0x3a {
                         self.cursor = (((self.cursor as usize / 0x40) + 1) * 0x40) as *mut u16;
                     }
+                    self.cursor
+                        .write_volatile((ascii | ((self.palette as u32) << 12)) as u16);
+                    self.cursor = self.cursor.add(1);
                 }
             }
         }

--- a/tests/multiple_ignore/.cargo/config.toml
+++ b/tests/multiple_ignore/.cargo/config.toml
@@ -1,0 +1,9 @@
+[build]
+target = "thumbv4t-none-eabi"
+
+[target.thumbv4t-none-eabi]
+runner = "mgba"
+rustflags = ["-Clinker=arm-none-eabi-ld", "-Clink-arg=-Tgba.ld", "-Ztrap-unreachable=no"]
+
+[unstable]
+build-std = ["core"]

--- a/tests/multiple_ignore/Cargo.toml
+++ b/tests/multiple_ignore/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "multiple_ignore"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[profile.dev]
+opt-level = 3
+
+[profile.release]
+lto = true
+
+[dependencies]
+gba_test = {path = "../../gba_test"}

--- a/tests/multiple_ignore/src/lib.rs
+++ b/tests/multiple_ignore/src/lib.rs
@@ -1,0 +1,37 @@
+//! Defines a single basic test.
+
+#![no_std]
+#![no_main]
+#![feature(custom_test_frameworks)]
+#![test_runner(gba_test::runner)]
+#![reexport_test_harness_main = "test_harness"]
+
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+#[no_mangle]
+pub fn main() {
+    test_harness()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::add;
+    use gba_test::test;
+
+    #[test]
+    #[ignore]
+    fn it_works_with_a_long_name() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+
+    #[test]
+    #[ignore]
+    fn it_works_with_a_long_name_2() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
Fixes #1.

This introduces a new test that shows the problem:

![multiple_ignore-798e27f1ad2bdd8f-0](https://github.com/Anders429/gba_test/assets/31867211/2570e6ab-cf15-4864-9722-8ddaa83bd9e9)

After applying the fix, we see the problem is fixed:

![multiple_ignore-798e27f1ad2bdd8f-1](https://github.com/Anders429/gba_test/assets/31867211/1e02dec6-ca86-455d-9174-91c0ed7a910d)
