### PR TITLE
Remove `naked_functions` unstable feature

### DIFF
--- a/gba_test/CHANGELOG.md
+++ b/gba_test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Resolved issue with unstable `naked_functions` feature which caused compilation failures on the latest nightly builds.
+### Removed
+- Reliance on `asm_const` unstable feature (the feature was recently stabilized).
+- Reliance on `naked_functions` unstable feature, instead implementing the runtime using `global_asm!`.
+
 ## 0.1.3 - 2024-06-17
 ### Fixed
 - Panic displaying now properly clears all previous text before displaying the panic info.

--- a/gba_test/src/lib.rs
+++ b/gba_test/src/lib.rs
@@ -76,7 +76,7 @@
 #![cfg_attr(test, test_runner(runner))]
 #![cfg_attr(test, reexport_test_harness_main = "test_harness")]
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
-#![allow(clippy::needless_doctest_main)]
+#![allow(clippy::needless_doctest_main, static_mut_refs)]
 
 #[cfg(test)]
 extern crate self as gba_test;

--- a/gba_test/src/lib.rs
+++ b/gba_test/src/lib.rs
@@ -73,7 +73,6 @@
 //! potentially breaking this framework.
 
 #![no_std]
-#![feature(naked_functions)]
 #![cfg_attr(test, no_main)]
 #![cfg_attr(test, feature(custom_test_frameworks))]
 #![cfg_attr(test, test_runner(runner))]

--- a/gba_test/src/lib.rs
+++ b/gba_test/src/lib.rs
@@ -64,12 +64,10 @@
 //! will not cause any problems for downstream users.
 //!
 //! # Stability
-//! This library relies the following unstable language features:
+//! This library relies the following unstable language feature:
 //! - [`custom_test_frameworks`](https://doc.rust-lang.org/unstable-book/language-features/custom-test-frameworks.html)
-//! - [`asm_const`](https://doc.rust-lang.org/unstable-book/language-features/asm-const.html)
-//! - [`naked_functions`](https://doc.rust-lang.org/unstable-book/language-features/naked-functions.html)
 //!
-//! As such, the stability cannot be guaranteed. These features are subject to change at any time,
+//! As such, the stability cannot be guaranteed. This feature is subject to change at any time,
 //! potentially breaking this framework.
 
 #![no_std]

--- a/gba_test/src/runtime.rs
+++ b/gba_test/src/runtime.rs
@@ -1,3 +1,5 @@
+use core::arch::global_asm;
+
 #[derive(Debug)]
 #[repr(transparent)]
 struct DmaControl(u16);
@@ -22,108 +24,110 @@ const DMA_32_BIT_MEMCPY: DmaControl = DmaControl::new()
 const DMA3_OFFSET: usize = 0x0000_00D4;
 const IME_OFFSET: usize = 0x0000_0208;
 
-#[naked]
-#[no_mangle]
-#[instruction_set(arm::a32)]
-#[link_section = ".entrypoint"]
-unsafe extern "C" fn __start() -> ! {
-    core::arch::asm!(
-        "b 1f",
-        ".space 0xE0", /* space for header */
-        "1:", /* post header */
-        "mov r12, #{mmio_base}",
-        "add r0, r12, #{waitcnt_offset}",
-        "ldr r1, ={waitcnt_setting}",
-        "strh r1, [r0]",
+global_asm! {
+    ".section .entrypoint,\"ax\",%progbits",
+    ".global __start",
+    "__start:",
 
-        /* iwram copy */
-        "ldr r4, =__iwram_word_copy_count",
-        "cmp r4, #0",
-        "beq 2 f",
-        "add r3, r12, #{dma3_offset}",
-        "mov r5, #{dma3_setting}",
-        "ldr r0, =__iwram_start",
-        "ldr r2, =__iwram_position_in_rom",
-        "str r2, [r3]", /* source */
-        "str r0, [r3, #4]", /* destination */
-        "strh r4, [r3, #8]", /* word count */
-        "strh r5, [r3, #10]", /* set control bits */
-        "2:",
+    ".code 32",
 
-        /* ewram copy */
-        "ldr r4, =__ewram_word_copy_count",
-        "cmp r4, #0",
-        "beq 3 f",
-        "add r3, r12, #{dma3_offset}",
-        "mov r5, #{dma3_setting}",
-        "ldr r0, =__ewram_start",
-        "ldr r2, =__ewram_position_in_rom",
-        "str r2, [r3]", /* source */
-        "str r0, [r3, #4]", /* destination */
-        "strh r4, [r3, #8]", /* word count */
-        "strh r5, [r3, #10]", /* set control bits */
-        "3:",
+    "b 1f",
+    ".space 0xE0", /* space for header */
+    "1:", /* post header */
+    "mov r12, #{mmio_base}",
+    "add r0, r12, #{waitcnt_offset}",
+    "ldr r1, ={waitcnt_setting}",
+    "strh r1, [r0]",
 
-        /* bss zero */
-        "ldr r4, =__bss_word_clear_count",
-        "cmp r4, #0",
-        "beq 4 f",
-        "ldr r0, =__bss_start",
-        "mov r2, #0",
-        "2:",
-        "str r2, [r0], #4",
-        "subs r4, r4, #1",
-        "bne 2b",
-        "4:",
+    /* iwram copy */
+    "ldr r4, =__iwram_word_copy_count",
+    "cmp r4, #0",
+    "beq 2 f",
+    "add r3, r12, #{dma3_offset}",
+    "mov r5, #{dma3_setting}",
+    "ldr r0, =__iwram_start",
+    "ldr r2, =__iwram_position_in_rom",
+    "str r2, [r3]", /* source */
+    "str r0, [r3, #4]", /* destination */
+    "strh r4, [r3, #8]", /* word count */
+    "strh r5, [r3, #10]", /* set control bits */
+    "2:",
 
-        /* assign the runtime irq handler */
-        "ldr r1, ={runtime_irq_handler}",
-        "str r1, [r12, #-4]",
+    /* ewram copy */
+    "ldr r4, =__ewram_word_copy_count",
+    "cmp r4, #0",
+    "beq 3 f",
+    "add r3, r12, #{dma3_offset}",
+    "mov r5, #{dma3_setting}",
+    "ldr r0, =__ewram_start",
+    "ldr r2, =__ewram_position_in_rom",
+    "str r2, [r3]", /* source */
+    "str r0, [r3, #4]", /* destination */
+    "strh r4, [r3, #8]", /* word count */
+    "strh r5, [r3, #10]", /* set control bits */
+    "3:",
 
-         /* call to rust main */
-        "ldr r0, =main",
-        "bx r0",
-        // main shouldn't return, but if it does just SoftReset
-        "swi #0",
-        mmio_base = const 0x0400_0000,
-        waitcnt_offset = const 0x204,
-        waitcnt_setting = const 0x4317 /*sram8,r0:3.1,r1:4.2,r2:8.2,no_phi,prefetch*/,
-        dma3_offset = const DMA3_OFFSET,
-        dma3_setting = const DMA_32_BIT_MEMCPY.0,
-        runtime_irq_handler = sym runtime_irq_handler,
-        options(noreturn)
-    )
+    /* bss zero */
+    "ldr r4, =__bss_word_clear_count",
+    "cmp r4, #0",
+    "beq 4 f",
+    "ldr r0, =__bss_start",
+    "mov r2, #0",
+    "2:",
+    "str r2, [r0], #4",
+    "subs r4, r4, #1",
+    "bne 2b",
+    "4:",
+
+    /* assign the runtime irq handler */
+    "ldr r1, =__runtime_irq_handler",
+    "str r1, [r12, #-4]",
+
+        /* call to rust main */
+    "ldr r0, =main",
+    "bx r0",
+    // main shouldn't return, but if it does just SoftReset
+    "swi #0",
+
+    ".code 16",
+
+    mmio_base = const 0x0400_0000,
+    waitcnt_offset = const 0x204,
+    waitcnt_setting = const 0x4317 /*sram8,r0:3.1,r1:4.2,r2:8.2,no_phi,prefetch*/,
+    dma3_offset = const DMA3_OFFSET,
+    dma3_setting = const DMA_32_BIT_MEMCPY.0,
 }
 
-#[naked]
-#[no_mangle]
-#[instruction_set(arm::a32)]
-#[link_section = ".iwram.runtime.irq.handler"]
-unsafe extern "C" fn runtime_irq_handler() {
-    // On Entry: r0 = 0x0400_0000 (mmio_base)
-    core::arch::asm!(
-      /* swap IME off, user can turn it back on if they want */
-      "add r12, r0, #{ime_offset}",
-      "mov r3, #0",
-      "swp r3, r3, [r12]",
+global_asm! {
+    ".section .iwram.runtime.irq.handler,\"ax\",%progbits",
+    ".global __runtime_irq_handler",
+    "__runtime_irq_handler:",
 
-      /* Read/Update IE and IF */
-      "ldr r0, [r12, #-8]",
-      "and r0, r0, r0, LSR #16",
-      "strh r0, [r12, #-6]",
+    ".code 32",
 
-      /* Read/Update BIOS_IF */
-      "sub  r2, r12, #(0x208+8)",
-      "ldrh r1, [r2]",
-      "orr  r1, r1, r0",
-      "strh r1, [r2]",
+    /* swap IME off, user can turn it back on if they want */
+    "add r12, r0, #{ime_offset}",
+    "mov r3, #0",
+    "swp r3, r3, [r12]",
 
-      /* Restore initial IME setting and return */
-      "swp r3, r3, [r12]",
-      "bx lr",
-      ime_offset = const IME_OFFSET,
-      options(noreturn)
-    )
+    /* Read/Update IE and IF */
+    "ldr r0, [r12, #-8]",
+    "and r0, r0, r0, LSR #16",
+    "strh r0, [r12, #-6]",
+
+    /* Read/Update BIOS_IF */
+    "sub  r2, r12, #(0x208+8)",
+    "ldrh r1, [r2]",
+    "orr  r1, r1, r0",
+    "strh r1, [r2]",
+
+    /* Restore initial IME setting and return */
+    "swp r3, r3, [r12]",
+    "bx lr",
+
+    ".code 16",
+
+    ime_offset = const IME_OFFSET,
 }
 
 #[no_mangle]


### PR DESCRIPTION
Fixes #6. This should hopefully prevent issues like this again in the future, at least until something happens with the `custom_test_frameworks` feature, as the other unstable features have been removed.